### PR TITLE
H310 idrac fanfix

### DIFF
--- a/docs/H310.md
+++ b/docs/H310.md
@@ -73,22 +73,6 @@ flashboot /root/Bootloaders/x64sas2.rom
 ```
 You can now ditch the live images and boot back into your normal system.
 
-## Optional: (Dell) Modify RACADM
-
->Warning: Use this at your own risk.  Modifying thermal settings can cause unforeseen circumstances.  If you are running your server in a warm environment, it is probably best to leave this alone.
-
-The LSI firmware is not supported by Dell.  This means the iDRAC will no longer keep track of the drive temperatures.  This will cause the iDRAC to throw error PCI3018 in the Lifecycle Log and set the fans to a static speed of about 30%.  It uses this static fan speed as a failsafe to prevent any disks from possibly overheating.  
-
-To correct this, you can disable the "ThirdPartyPCIFanResponse" feature by using RACADM.  The easiest way to do this is to connect to the iDRAC using an SSH client.  Once connected, run this command: 
-```
-racadm set system.thermalsettings.ThirdPartyPCIFanResponse 0
-```
-If you need to revert, run this command instead:
-```
-racadm set system.thermalsettings.ThirdPartyPCIFanResponse 1
-```
->Note: This information was collected from the Dell iDRAC9 User's Guide which can be referenced here: https://dl.dell.com/topicspdf/idrac9-lifecycle-controller-v33-series_users-guide6_en-us.pdf .  The relevant information can be found near the bottom of page 57.
-
 ## Optional: Reverting
 If for some reason you need to revert back to the stock Dell PERC firmware, that's easy. Boot into the FreeDOS live image, and run the following command:
 ```

--- a/docs/H310.md
+++ b/docs/H310.md
@@ -75,9 +75,9 @@ You can now ditch the live images and boot back into your normal system.
 
 ## Optional: (Dell) Modify RACADM
 
->Warning: Use this at your own risk.  Modifying thermal settings can create unforseen circumstances.  If you are running your server in a warm environment, it is probably best to leave this alone.
+>Warning: Use this at your own risk.  Modifying thermal settings can cause unforeseen circumstances.  If you are running your server in a warm environment, it is probably best to leave this alone.
 
-The LSI firmware is not supported by Dell.  This causes the iDRAC to no longer keep track of the drive temperatures.  In response, the iDRAC will throw error PCI3018 in the Lifecycle Log and set the fans to a static speed of about 30%.  
+The LSI firmware is not supported by Dell.  This means the iDRAC will no longer keep track of the drive temperatures.  This will cause the iDRAC to throw error PCI3018 in the Lifecycle Log and set the fans to a static speed of about 30%.  It uses this static fan speed as a failsafe to prevent any disks from possibly overheating.  
 
 To correct this, you can disable the "ThirdPartyPCIFanResponse" feature by using RACADM.  The easiest way to do this is to connect to the iDRAC using an SSH client.  Once connected, run this command: 
 ```

--- a/docs/H310.md
+++ b/docs/H310.md
@@ -73,6 +73,22 @@ flashboot /root/Bootloaders/x64sas2.rom
 ```
 You can now ditch the live images and boot back into your normal system.
 
+## Optional: (Dell) Modify RACADM
+
+>Warning: Use this at your own risk.  Modifying thermal settings can create unforseen circumstances.  If you are running your server in a warm environment, it is probably best to leave this alone.
+
+The LSI firmware is not supported by Dell.  This causes the iDRAC to no longer keep track of the drive temperatures.  In response, the iDRAC will throw error PCI3018 in the Lifecycle Log and set the fans to a static speed of about 30%.  
+
+To correct this, you can disable the "ThirdPartyPCIFanResponse" feature by using RACADM.  The easiest way to do this is to connect to the iDRAC using an SSH client.  Once connected, run this command: 
+```
+racadm set system.thermalsettings.ThirdPartyPCIFanResponse 0
+```
+If you need to revert, run this command instead:
+```
+racadm set system.thermalsettings.ThirdPartyPCIFanResponse 1
+```
+>Note: This information was collected from the Dell iDRAC9 User's Guide which can be referenced here: https://dl.dell.com/topicspdf/idrac9-lifecycle-controller-v33-series_users-guide6_en-us.pdf .  The relevant information can be found near the bottom of page 57.
+
 ## Optional: Reverting
 If for some reason you need to revert back to the stock Dell PERC firmware, that's easy. Boot into the FreeDOS live image, and run the following command:
 ```

--- a/docs/perc.md
+++ b/docs/perc.md
@@ -62,6 +62,54 @@ If it displays an **H810 Adapter D1** revision, proceed to the [H810 Full Size (
 
 If it displays anything that doesn't exactly match the above choices, [contact me](mailto:jon@fohdeesha.com?subject=PERC-Unknown) with a screenshot. If you're impatient and pick the "closest one" instead, you'll brick your card.
 
+## Extra: Disable ThirdPartyPCIFanResponse
+
+>Warning: Use this at your own risk.  Modifying thermal settings can cause unforeseen circumstances.  If you are running your server in a warm environment, it is probably best to leave this alone.
+
+The LSI firmware is not supported by Dell.  This will cause the iDRAC to no longer keep track of the drive temperatures.  This is confirmed with the error PCI3018 in the Lifecycle Log and the fans being set to a static speed of about 30%.  The fan speed acts as a failsafe to prevent any disks from possibly overheating.  
+
+To correct this behavior, you can disable the "ThirdPartyPCIFanResponse" feature by using IPMItool or RACADM.  IPMItool is built into the live image so this will usually be the easiest option.  If you are no longer booted into the live image, use the RACADM option instead to disable via SSH.
+
+### Option 1: Disable ThirdPartyPCIFanResponse using IPMItool via Linux Shell
+
+IPMItool is built into the live image.  Otherwise, you will need to install IPMItool in a Linux environment first.
+
+To disable ThirdPartyPCIFanResponse, run the following command in the Linux shell:
+```
+ipmitool –I open raw 0x30 0xce 0 0x16 5 0 0 0 5 0 1 0 0
+```
+
+To verify if the option is enabled or not, run this command in the Linux shell:
+```
+ipmitool –I open raw 0x30 0xce 1 0x16 5 0 0 0
+```
+
+If you need to enable the feature again, run this command in the Linux shell:
+```
+ipmitool –I open raw 0x30 0xce 0 0x16 5 0 0 0 5 0 0 0 0
+```
+
+### Option 2: Disable ThirdPartyPCIFanResponse using RACADM via SSH
+
+Connect to port 22 on your iDRAC's IP address using your preferred SSH client.
+
+To disable ThirdPartyPCIFanResponse, run the following command via the SSH client:
+```
+racadm set system.thermalsettings.ThirdPartyPCIFanResponse 0
+```
+
+To verify if the option is enabled or not, run this command via the SSH client:
+```
+racadm getsystem.thermalsettings.ThirdPartyPCIFanResponse
+```
+
+If you need to enable the feature again, run this command via the SSH client:
+```
+racadm set system.thermalsettings.ThirdPartyPCIFanResponse 1
+```
+
+>Note: This information was collected from the Dell White Paper "Disabling a Third-Party PCIe Card Cooling Response with Dell PowerEdge Servers" which can be referenced here: https://fohdeesha.com/data/other/perc/ThirdPartyPCIFanResponse.pdf .  The relevant information can be found on pages 6 and 7.
+
 ## Extra: Revision Info & Part Numbers
 The main difference between the B0 and D1 revisions is the D1 will link at PCIe 3.0 speeds, instead of PCIe 2.0. This will almost certainly never cause a bottleneck unless you have every SAS port on the card connected to very fast SSDs that all get hammered at the same time. Even then, you're likely to reach the card's processor limitations before the bus bandwidth limit. The difference with the *P* cards (H710P) is more cache (1GB vs 512MB), but this is totally irrelevant when running the card flashed to IT mode as the cache is not used.
 

--- a/docs/perc.md
+++ b/docs/perc.md
@@ -108,7 +108,7 @@ If you need to enable the feature again, run this command via the SSH client:
 racadm set system.thermalsettings.ThirdPartyPCIFanResponse 1
 ```
 
->Note: This information was collected from the Dell White Paper "Disabling a Third-Party PCIe Card Cooling Response with Dell PowerEdge Servers" which can be referenced here: https://fohdeesha.com/data/other/perc/ThirdPartyPCIFanResponse.pdf .  The relevant information can be found on pages 6 and 7.
+>Note: This information was collected from the Dell White Paper "Disabling a Third-Party PCIe Card Cooling Response with Dell PowerEdge Servers" which can be referenced here: https://fohdeesha.com/data/other/perc/ThirdPartyPCIFanResponse.pdf .
 
 ## Extra: Revision Info & Part Numbers
 The main difference between the B0 and D1 revisions is the D1 will link at PCIe 3.0 speeds, instead of PCIe 2.0. This will almost certainly never cause a bottleneck unless you have every SAS port on the card connected to very fast SSDs that all get hammered at the same time. Even then, you're likely to reach the card's processor limitations before the bus bandwidth limit. The difference with the *P* cards (H710P) is more cache (1GB vs 512MB), but this is totally irrelevant when running the card flashed to IT mode as the cache is not used.


### PR DESCRIPTION
Hello,

I found your guide from a user on the FreeNAS forums and I thought I'd contribute what I recently discovered on my own server.  I'm using an H310 flashed with the LSI firmware on a Dell T320.  

After I updated the firmware, I noticed the fans were running much more loudly than before.  After looking through the logs, I found an error PCI3018 in the Lifecycle log.  I also noticed that all the RAID/HBA card options were disabled in the iDRAC web GUI.  

I searched online and I found a few people who had the same issue but their only solution was to manually set the fan speed until they were happy with the result.  I did not like this solution as I believe this set all the fans to the same static setting instead of fixing just the front fans which were the issue.

After doing my own research, I discovered a setting in RACADM to disable "ThirdPartyPCIFanResponse".  After I disabled this feature, the fans went back to their normal volume.  You can find reference to this on the iDRAC User's Guide near the bottom of page 57 https://dl.dell.com/topicspdf/idrac9-lifecycle-controller-v33-series_users-guide6_en-us.pdf .

I've been running with this setting for a few months and I haven't found any issues yet.  I originally posted about this on the FreeNAS forums here https://www.truenas.com/community/threads/how-is-dell-t320.89456/#post-620636 .  I think this would make a good addition to your manual.  I've only tested it on the H310 so I only added it on the H310 instructions as an optional step with a warning to "use at your own risk".

This is my first public pull request on Github so please be gentle 😄 .  Feel free to let me know if I'm missing something or if you need more info.