### PR TITLE
Fix incorrect fan percentage

### DIFF
--- a/docs/perc.md
+++ b/docs/perc.md
@@ -66,7 +66,7 @@ If it displays anything that doesn't exactly match the above choices, [contact m
 
 >Warning: Use this at your own risk.  Modifying thermal settings can cause unforeseen circumstances.  If you are running your server in a hot environment, it's probably best to leave this alone
 
-iDRAC does not expect to see a PERC card running LSI firmware - this will cause the iDRAC to no longer see the drive temperatures. In some cases, this will cause the error PCI3018 in the Lifecycle Log, and the fans will be set to a static speed of about 30%. The fan speed acts as a failsafe to prevent any disks from possibly overheating.
+iDRAC does not expect to see a PERC card running LSI firmware - this will cause the iDRAC to no longer see the drive temperatures. In some cases, this will cause the error PCI3018 in the Lifecycle Log, and the fans will be set to a static speed of about 75%. The fan speed acts as a failsafe to prevent any disks from possibly overheating.
 
 If you are affected by this and would like the fan behavior to return to normal, you can disable the `ThirdPartyPCIFanResponse` feature by using IPMItool or RACADM. IPMItool is built into the live image so this will usually be the easiest option.  If you don't want to use the Linux live ISO, you can use the RACADM option to disable it via SSH.
 


### PR DESCRIPTION
Changed line 69 to show static speed of about 75% instead of 30%.

I was perusing through your other project for idrac reverse engineering and ran across a section about the same feature here: https://github.com/Fohdeesha/idrac-7-8-reverse-engineering/tree/master/squashfs-ipmi#thermal--fans .  You had found the fan speed was actually 75% with an unknown PCI-e card.  I believe 75% is likely the more accurate reading.  The 30% I was reading from was in the sensors menu and that might be what it would set it to if the fan speeds weren't static.