### PR TITLE
change reset to boot_primary

### DIFF
--- a/docs/icx7150.md
+++ b/docs/icx7150.md
@@ -34,7 +34,7 @@ After a couple minutes, it should complete. Now we clear the temporary IP, then 
 ```
 setenv ipaddr
 saveenv
-reset
+boot_primary
 ```
 ## First Boot & Login
 This first boot will take a few minutes - you'll see messages regarding a PoE firmware update taking place, and likely errors regarding boot-monitor mismatches and incompatible package versions - these are all expected and can be ignored. They will be remedied by the next reboot when the new bootloader is used. Hit enter and you should be given a login prompt. The default login is now:


### PR DESCRIPTION
I have seen on a few switches (4 so far) that they come with the secondary flash as default boot. Even after doing factory set-default it will still boot the secondary flash after updating from the bootloader. The switch models I've experienced this on were the ICX7150 and ICX7250. Since the guide flashes the primary we can just guide people to boot the primary so there is no confusion in case it boots from secondary. If it doesn't make sent to change this line we can just add a note to try booting from primary.