### PR TITLE
Update icx6xxx-adv.md ssh config

### DIFF
--- a/docs/icx6xxx-adv.md
+++ b/docs/icx6xxx-adv.md
@@ -141,13 +141,11 @@ On linux and macOS you'll want to add these lines to your ```~\.ssh\config``` fi
 
 ```
 Host <switch-ip>
-   User root
    IdentitiesOnly yes
    IdentityFile ~/.ssh/private_key
    KexAlgorithms +diffie-hellman-group1-sha1
    PubkeyAcceptedKeyTypes=+ssh-rsa
    HostKeyAlgorithms=+ssh-rsa
-   PreferredAuthentications publickey
 ```
 
 

--- a/docs/icx6xxx-adv.md
+++ b/docs/icx6xxx-adv.md
@@ -137,13 +137,17 @@ ip ssh pub-key-file tftp 192.168.1.8 public.key
 ```
 You shouldn't need to be told basic key management if you're following this section, but just in case - copy your private key to the proper location on the *nix machine you'll be SSH'ing from, or if you're on windows, load it using [pageant](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html). Now when you SSH to the switch, it will authenticate using your private key.
 
-On linux and macOS you'll want to add these lines to your ```~\.ssh\config``` file. IdentitiesOnly is to prevent ssh-agent from offering any other bigger (> 2048) keys first that will terminate the connection negotiation early. IdentityFile will use only this key for this connection. KexAlgorithms sets a key exchange algorithm that the older ICX6xxx series accepts:
+On linux and macOS you'll want to add these lines to your ```~\.ssh\config``` file. IdentitiesOnly is to prevent ssh-agent from offering any other bigger (> 2048) keys first that will terminate the connection negotiation early. IdentityFile will use only this key for this connection. KexAlgorithms sets a key exchange algorithm that the older ICX6xxx series accepts.  The PubkeyAcceptedKeyTypes must be set as the algorithm is off by default more frequently, along with the HostKeyAlgorithm, to match what the ICX6xxx can offer:
 
 ```
 Host <switch-ip>
+   User root
    IdentitiesOnly yes
    IdentityFile ~/.ssh/private_key
    KexAlgorithms +diffie-hellman-group1-sha1
+   PubkeyAcceptedKeyTypes=+ssh-rsa
+   HostKeyAlgorithms=+ssh-rsa
+   PreferredAuthentications publickey
 ```
 
 


### PR DESCRIPTION
I've seen a couple questions, one on the STH thread and one on Reddit, where SSH is failing due to the lack of "ssh-rsa" options.  These changes to the documentation should help future beefers.